### PR TITLE
feat: add easter eggs system with multiple hidden bonuses

### DIFF
--- a/EASTER_EGGS.md
+++ b/EASTER_EGGS.md
@@ -1,0 +1,141 @@
+# Easter Eggs Guide
+
+This game contains several hidden easter eggs that grant bonus coins and power-ups. Can you find them all?
+
+---
+
+## 1. Wolf Mode (URL Parameter)
+
+**Difficulty:** Easy
+**Reward:** 99,999 coins, max lives, 99 hammers
+
+### How to Activate
+Add `?wolf=true` to the game URL:
+```
+http://localhost:3035/?wolf=true
+```
+
+### What You Get
+- 99,999 coins (essentially unlimited)
+- All 5 lives restored
+- 99 hammers
+
+*This is essentially "god mode" for testing or just having fun!*
+
+---
+
+## 2. Konami Code
+
+**Difficulty:** Medium
+**Reward:** 500 coins, 10 hammers
+
+### How to Activate
+Enter the classic Konami code on your keyboard:
+
+```
+↑ ↑ ↓ ↓ ← → ← → B A
+```
+
+**Keys to press:**
+1. Up Arrow (twice)
+2. Down Arrow (twice)
+3. Left Arrow
+4. Right Arrow
+5. Left Arrow
+6. Right Arrow
+7. B key
+8. A key
+
+**Tips:**
+- You have 2 seconds between key presses before the sequence resets
+- Works on any screen in the game
+- Can only be activated once per session
+
+---
+
+## 3. Secret Corner Click
+
+**Difficulty:** Hard
+**Reward:** 250 coins, 5 hammers
+
+### How to Activate
+Click the **corner cells of the game board** in this specific order:
+
+```
+Top-Left Cell → Top-Right Cell → Bottom-Right Cell → Bottom-Left Cell → Top-Left Cell
+```
+
+Think of it as tracing the board clockwise, then returning to the start.
+
+**Diagram (click the corner gems on the board):**
+```
+[1,5][ ][ ][ ][ ][ ][ ][2]
+[ ]                    [ ]
+[ ]                    [ ]
+[ ]                    [ ]
+[ ]                    [ ]
+[ ]                    [ ]
+[ ]                    [ ]
+[4][ ][ ][ ][ ][ ][ ][3]
+```
+
+**Tips:**
+- Click directly on the corner **gem cells** of the board
+- You have 3 seconds between clicks before the sequence resets
+- Any click outside a corner cell resets the sequence
+- Can only be activated once per session
+- Must be on the game board screen to work
+
+---
+
+## 4. Special Date Bonuses
+
+**Difficulty:** Just show up!
+**Reward:** 100 coins, 3 hammers
+
+### Special Dates
+Play the game on these special dates to receive automatic bonuses:
+
+| Date | Holiday | Emoji |
+|------|---------|-------|
+| January 1 | New Year's Day | 🎆 |
+| February 14 | Valentine's Day | 💝 |
+| March 17 | St. Patrick's Day | ☘️ |
+| April 1 | April Fools' Day | 🃏 |
+| July 4 | Independence Day | 🎆 |
+| October 31 | Halloween | 🎃 |
+| December 25 | Christmas | 🎄 |
+| December 31 | New Year's Eve | 🥳 |
+
+**Tips:**
+- Bonuses are automatically applied when you load the game on a special date
+- Each date bonus can only be claimed once per day
+- The bonus persists in localStorage, so refreshing won't give it again
+
+---
+
+## Summary
+
+| Easter Egg | Coins | Hammers | Lives | Difficulty |
+|------------|-------|---------|-------|------------|
+| Wolf Mode | 99,999 | 99 | Max | Easy |
+| Konami Code | 500 | 10 | - | Medium |
+| Corner Click | 250 | 5 | - | Hard |
+| Date Bonus | 100 | 3 | - | Show up! |
+
+---
+
+## Developer Notes
+
+All easter eggs log their activation to the browser console with `[EasterEgg]` prefix. Open your browser's developer tools (F12) to see activation messages.
+
+Example console output:
+```
+[EasterEgg] 🐺 WOLF MODE ACTIVATED! 🐺
+[EasterEgg] Granted 99999 coins
+[EasterEgg] Lives set to maximum (5)
+[EasterEgg] Granted 99 hammers
+[EasterEgg] 🐺 You are now in god mode! Have fun! 🐺
+```
+
+Happy hunting! 🎮

--- a/docs/EASTER_EGGS.md
+++ b/docs/EASTER_EGGS.md
@@ -1,0 +1,137 @@
+# Easter Eggs Guide
+
+This game contains several hidden easter eggs that grant bonus coins and power-ups. Can you find them all?
+
+---
+
+## 1. Wolf Mode (URL Parameter)
+
+**Difficulty:** Easy
+**Reward:** 99,999 coins, max lives, 99 hammers
+
+### How to Activate
+Add `?wolf=true` to the game URL:
+```
+http://localhost:3035/?wolf=true
+```
+
+### What You Get
+- 99,999 coins (essentially unlimited)
+- All 5 lives restored
+- 99 hammers
+
+*This is essentially "god mode" for testing or just having fun!*
+
+---
+
+## 2. Konami Code
+
+**Difficulty:** Medium
+**Reward:** 500 coins, 10 hammers
+
+### How to Activate
+Enter the classic Konami code on your keyboard:
+
+```
+↑ ↑ ↓ ↓ ← → ← → B A
+```
+
+**Keys to press:**
+1. Up Arrow (twice)
+2. Down Arrow (twice)
+3. Left Arrow
+4. Right Arrow
+5. Left Arrow
+6. Right Arrow
+7. B key
+8. A key
+
+**Tips:**
+- You have 2 seconds between key presses before the sequence resets
+- Works on any screen in the game
+- Can only be activated once per session
+
+---
+
+## 3. Secret Corner Click
+
+**Difficulty:** Hard
+**Reward:** 250 coins, 5 hammers
+
+### How to Activate
+Click the corners of the screen in this specific order:
+
+```
+Top-Left → Top-Right → Bottom-Right → Bottom-Left → Top-Left
+```
+
+Think of it as tracing a rectangle clockwise, then returning to the start.
+
+**Diagram:**
+```
+[1,5]─────────[2]
+  │             │
+  │             │
+  │             │
+ [4]─────────[3]
+```
+
+**Tips:**
+- Clicks must be within 100 pixels of each corner
+- You have 3 seconds between clicks before the sequence resets
+- Any click outside a corner resets the sequence
+- Can only be activated once per session
+
+---
+
+## 4. Special Date Bonuses
+
+**Difficulty:** Just show up!
+**Reward:** 100 coins, 3 hammers
+
+### Special Dates
+Play the game on these special dates to receive automatic bonuses:
+
+| Date | Holiday | Emoji |
+|------|---------|-------|
+| January 1 | New Year's Day | 🎆 |
+| February 14 | Valentine's Day | 💝 |
+| March 17 | St. Patrick's Day | ☘️ |
+| April 1 | April Fools' Day | 🃏 |
+| July 4 | Independence Day | 🎆 |
+| October 31 | Halloween | 🎃 |
+| December 25 | Christmas | 🎄 |
+| December 31 | New Year's Eve | 🥳 |
+
+**Tips:**
+- Bonuses are automatically applied when you load the game on a special date
+- Each date bonus can only be claimed once per day
+- The bonus persists in localStorage, so refreshing won't give it again
+
+---
+
+## Summary
+
+| Easter Egg | Coins | Hammers | Lives | Difficulty |
+|------------|-------|---------|-------|------------|
+| Wolf Mode | 99,999 | 99 | Max | Easy |
+| Konami Code | 500 | 10 | - | Medium |
+| Corner Click | 250 | 5 | - | Hard |
+| Date Bonus | 100 | 3 | - | Show up! |
+
+---
+
+## Developer Notes
+
+All easter eggs log their activation to the browser console with `[EasterEgg]` prefix. Open your browser's developer tools (F12) to see activation messages.
+
+Example console output:
+```
+[EasterEgg] 🐺 WOLF MODE ACTIVATED! 🐺
+[EasterEgg] Granted 99999 coins
+[EasterEgg] Lives set to maximum (5)
+[EasterEgg] Granted 99 hammers
+[EasterEgg] 🐺 You are now in god mode! Have fun! 🐺
+```
+
+Happy hunting! 🎮

--- a/e2e/easter-eggs.spec.ts
+++ b/e2e/easter-eggs.spec.ts
@@ -1,0 +1,299 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Easter Eggs', () => {
+  test.describe('Wolf Mode (URL parameter)', () => {
+    test('should activate wolf mode with ?wolf=true', async ({ page }) => {
+      // Navigate directly with wolf=true parameter (fresh page, no prior state)
+      await page.goto('/?wolf=true&skipMenu=true&board=test');
+
+      // Wait for game to initialize
+      await page.waitForFunction(() => {
+        const statusEl = document.getElementById('game-status');
+        return statusEl && statusEl.getAttribute('data-scene-ready') === 'true';
+      }, { timeout: 10000 });
+
+      // Wait a bit for easter egg to process and save
+      await page.waitForTimeout(500);
+
+      // Verify wolf mode activated by checking EasterEggManager status
+      const wolfActivated = await page.evaluate(() => {
+        // Access the global EasterEggManager instance
+        return (window as any).easterEggManager?.isWolfModeActive?.() ?? false;
+      });
+
+      // Verify resources were granted by checking MetaProgressionManager
+      const coins = await page.evaluate(() => {
+        const saved = localStorage.getItem('match3_meta_progression');
+        if (saved) {
+          const state = JSON.parse(saved);
+          return state.coins;
+        }
+        return 0;
+      });
+
+      // Wolf mode grants 99999 coins
+      expect(coins).toBeGreaterThanOrEqual(99999);
+
+      await page.screenshot({ path: 'screenshots/e2e-easter-egg-wolf-mode.png' });
+    });
+  });
+
+  test.describe('Konami Code', () => {
+    test('should activate konami code easter egg', async ({ page }) => {
+      // Set up console message capture
+      const consoleMessages: string[] = [];
+      page.on('console', msg => consoleMessages.push(msg.text()));
+
+      await page.goto('/?skipMenu=true&board=test');
+
+      // Wait for game to initialize
+      await page.waitForFunction(() => {
+        const statusEl = document.getElementById('game-status');
+        return statusEl && statusEl.getAttribute('data-scene-ready') === 'true';
+      }, { timeout: 10000 });
+
+      await page.waitForTimeout(500);
+
+      // Get initial coin count
+      const initialCoins = await page.evaluate(() => {
+        const saved = localStorage.getItem('match3_meta_progression');
+        if (saved) {
+          const state = JSON.parse(saved);
+          return state.coins;
+        }
+        return 0;
+      });
+
+      // Enter Konami code: ↑ ↑ ↓ ↓ ← → ← → B A
+      await page.keyboard.press('ArrowUp');
+      await page.keyboard.press('ArrowUp');
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('ArrowLeft');
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.press('ArrowLeft');
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.press('b');
+      await page.keyboard.press('a');
+
+      // Wait for activation
+      await page.waitForTimeout(500);
+
+      // Verify Konami code activated via console message
+      const konamiActivated = consoleMessages.some(msg => msg.includes('KONAMI CODE ACTIVATED'));
+      expect(konamiActivated).toBe(true);
+
+      // Verify coins increased (Konami grants 500 coins)
+      const finalCoins = await page.evaluate(() => {
+        const saved = localStorage.getItem('match3_meta_progression');
+        if (saved) {
+          const state = JSON.parse(saved);
+          return state.coins;
+        }
+        return 0;
+      });
+
+      expect(finalCoins).toBe(initialCoins + 500);
+
+      await page.screenshot({ path: 'screenshots/e2e-easter-egg-konami.png' });
+    });
+
+    test('should reset konami sequence on wrong key', async ({ page }) => {
+      // Set up console message capture
+      const consoleMessages: string[] = [];
+      page.on('console', msg => consoleMessages.push(msg.text()));
+
+      await page.goto('/?skipMenu=true&board=test');
+
+      await page.waitForFunction(() => {
+        const statusEl = document.getElementById('game-status');
+        return statusEl && statusEl.getAttribute('data-scene-ready') === 'true';
+      }, { timeout: 10000 });
+
+      await page.waitForTimeout(500);
+
+      // Enter partial konami code with wrong key in middle
+      await page.keyboard.press('ArrowUp');
+      await page.keyboard.press('ArrowUp');
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('ArrowLeft');
+      await page.keyboard.press('x'); // Wrong key - should reset
+      await page.keyboard.press('ArrowLeft');
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.press('b');
+      await page.keyboard.press('a');
+
+      await page.waitForTimeout(500);
+
+      // Konami code should NOT have activated
+      const konamiActivated = consoleMessages.some(msg => msg.includes('KONAMI CODE ACTIVATED'));
+      expect(konamiActivated).toBe(false);
+    });
+  });
+
+  test.describe('Secret Corner Click', () => {
+    test('should activate secret corner click easter egg', async ({ page }) => {
+      // Set up console message capture BEFORE navigation
+      const consoleMessages: string[] = [];
+      page.on('console', msg => consoleMessages.push(msg.text()));
+
+      // Use test board (4x3) for predictable corner positions
+      await page.goto('/?skipMenu=true&board=test');
+
+      // Wait for game to initialize
+      await page.waitForFunction(() => {
+        const statusEl = document.getElementById('game-status');
+        return statusEl && statusEl.getAttribute('data-scene-ready') === 'true';
+      }, { timeout: 10000 });
+
+      // Wait for canvas click listener to be attached
+      await page.waitForTimeout(1000);
+
+      // Get initial coin count
+      const initialCoins = await page.evaluate(() => {
+        const saved = localStorage.getItem('match3_meta_progression');
+        if (saved) {
+          const state = JSON.parse(saved);
+          return state.coins;
+        }
+        return 0;
+      });
+
+      const canvas = page.locator('canvas');
+
+      // Board layout for test board (3 cols x 4 rows):
+      // - offsetX: 50, offsetY: 150, cellSize: 80
+      // - Top-left cell (row=0, col=0): x=50+40=90, y=150+40=190
+      // - Top-right cell (row=0, col=2): x=50+2*80+40=250, y=190
+      // - Bottom-right cell (row=3, col=2): x=250, y=150+3*80+40=430
+      // - Bottom-left cell (row=3, col=0): x=90, y=430
+
+      // Click corners in sequence: TL -> TR -> BR -> BL -> TL
+      await canvas.click({ position: { x: 90, y: 190 } });   // Top-left (col=0, row=0)
+      await page.waitForTimeout(300);
+      await canvas.click({ position: { x: 250, y: 190 } });  // Top-right (col=2, row=0)
+      await page.waitForTimeout(300);
+      await canvas.click({ position: { x: 250, y: 430 } });  // Bottom-right (col=2, row=3)
+      await page.waitForTimeout(300);
+      await canvas.click({ position: { x: 90, y: 430 } });   // Bottom-left (col=0, row=3)
+      await page.waitForTimeout(300);
+      await canvas.click({ position: { x: 90, y: 190 } });   // Top-left again
+
+      // Wait for activation
+      await page.waitForTimeout(500);
+
+      // Log all easter egg messages as proof
+      const easterEggMessages = consoleMessages.filter(m => m.includes('[EasterEgg]'));
+      console.log('=== EASTER EGG CONSOLE OUTPUT ===');
+      easterEggMessages.forEach(m => console.log(m));
+      console.log('=================================');
+
+      // Verify coins increased (Secret click grants 250 coins)
+      const finalCoins = await page.evaluate(() => {
+        const saved = localStorage.getItem('match3_meta_progression');
+        if (saved) {
+          const state = JSON.parse(saved);
+          return state.coins;
+        }
+        return 0;
+      });
+
+      // Check if coins increased by 250
+      expect(finalCoins).toBe(initialCoins + 250);
+
+      await page.screenshot({ path: 'screenshots/e2e-easter-egg-corner-click.png' });
+    });
+
+    test('should reset corner sequence on non-corner click', async ({ page }) => {
+      // Set up console message capture
+      const consoleMessages: string[] = [];
+      page.on('console', msg => consoleMessages.push(msg.text()));
+
+      await page.goto('/?skipMenu=true&board=test');
+
+      await page.waitForFunction(() => {
+        const statusEl = document.getElementById('game-status');
+        return statusEl && statusEl.getAttribute('data-scene-ready') === 'true';
+      }, { timeout: 10000 });
+
+      await page.waitForTimeout(500);
+
+      const canvas = page.locator('canvas');
+
+      // Start sequence but click center cell to reset
+      await canvas.click({ position: { x: 90, y: 190 } });   // Top-left
+      await page.waitForTimeout(200);
+      await canvas.click({ position: { x: 330, y: 190 } });  // Top-right
+      await page.waitForTimeout(200);
+      await canvas.click({ position: { x: 210, y: 270 } });  // Center cell - resets sequence
+      await page.waitForTimeout(200);
+      await canvas.click({ position: { x: 90, y: 350 } });   // Bottom-left
+      await page.waitForTimeout(200);
+      await canvas.click({ position: { x: 90, y: 190 } });   // Top-left
+
+      await page.waitForTimeout(500);
+
+      // Secret click should NOT have activated
+      const secretActivated = consoleMessages.some(msg => msg.includes('SECRET CLICK SEQUENCE ACTIVATED'));
+      expect(secretActivated).toBe(false);
+    });
+  });
+
+  test.describe('Easter egg only activates once per session', () => {
+    test('konami code should only work once', async ({ page }) => {
+      // Set up console message capture
+      const consoleMessages: string[] = [];
+      page.on('console', msg => consoleMessages.push(msg.text()));
+
+      await page.goto('/?skipMenu=true&board=test');
+
+      await page.waitForFunction(() => {
+        const statusEl = document.getElementById('game-status');
+        return statusEl && statusEl.getAttribute('data-scene-ready') === 'true';
+      }, { timeout: 10000 });
+
+      await page.waitForTimeout(500);
+
+      // Enter Konami code first time
+      await page.keyboard.press('ArrowUp');
+      await page.keyboard.press('ArrowUp');
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('ArrowLeft');
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.press('ArrowLeft');
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.press('b');
+      await page.keyboard.press('a');
+
+      await page.waitForTimeout(500);
+
+      // Count how many times Konami was activated
+      const firstActivationCount = consoleMessages.filter(msg => msg.includes('KONAMI CODE ACTIVATED')).length;
+      expect(firstActivationCount).toBe(1);
+
+      // Enter Konami code second time
+      await page.keyboard.press('ArrowUp');
+      await page.keyboard.press('ArrowUp');
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('ArrowLeft');
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.press('ArrowLeft');
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.press('b');
+      await page.keyboard.press('a');
+
+      await page.waitForTimeout(500);
+
+      // Should still only be 1 activation (second attempt ignored)
+      const secondActivationCount = consoleMessages.filter(msg => msg.includes('KONAMI CODE ACTIVATED')).length;
+      expect(secondActivationCount).toBe(1);
+
+      // Should see "already activated" message
+      const alreadyActivated = consoleMessages.some(msg => msg.includes('already activated'));
+      expect(alreadyActivated).toBe(true);
+    });
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: 'http://localhost:3035',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
@@ -22,7 +22,7 @@ export default defineConfig({
 
   webServer: {
     command: 'npm run dev',
-    url: 'http://localhost:3000',
+    url: 'http://localhost:3035',
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/src/game/EasterEggManager.ts
+++ b/src/game/EasterEggManager.ts
@@ -56,6 +56,9 @@ export class EasterEggManager {
   private readonly SECRET_CLICK_SEQUENCE = ['TL', 'TR', 'BR', 'BL', 'TL'];
   private clickSequenceIndex = 0;
   private clickTimeout: number | null = null;
+  private lastCornerClicked: string | null = null;
+  private lastCornerClickTime = 0;
+  private readonly DEBOUNCE_MS = 300; // Ignore duplicate clicks within 300ms
 
   // Board layout for corner cell detection
   private boardLayout: BoardLayout | null = null;
@@ -162,6 +165,15 @@ export class EasterEggManager {
    * Process a corner click for the secret sequence
    */
   private processCornerClick(corner: string): void {
+    // Debounce: ignore duplicate clicks on the same corner within DEBOUNCE_MS
+    const now = Date.now();
+    if (corner === this.lastCornerClicked && (now - this.lastCornerClickTime) < this.DEBOUNCE_MS) {
+      console.log(`[EasterEgg] Ignoring duplicate click on ${corner} (debounce)`);
+      return;
+    }
+    this.lastCornerClicked = corner;
+    this.lastCornerClickTime = now;
+
     // Reset timeout on any corner click
     if (this.clickTimeout) {
       window.clearTimeout(this.clickTimeout);

--- a/src/game/EasterEggManager.ts
+++ b/src/game/EasterEggManager.ts
@@ -1,0 +1,529 @@
+/**
+ * EasterEggManager
+ *
+ * Manages easter eggs and cheat codes for the game.
+ * Includes URL parameters, Konami code, click sequences, and date-based surprises.
+ */
+
+import { MetaProgressionManager } from './MetaProgressionManager';
+import { PowerUpManager, PowerUpType } from './PowerUpManager';
+
+export interface EasterEggStatus {
+  wolfMode: boolean;
+  konamiMode: boolean;
+  secretClickMode: boolean;
+  dateBonus: string | null;
+  activated: string[];
+}
+
+export interface BoardLayout {
+  offsetX: number;
+  offsetY: number;
+  cellSize: number;
+  rows: number;
+  cols: number;
+}
+
+export class EasterEggManager {
+  private static instance: EasterEggManager;
+
+  // Wolf mode bonuses
+  private readonly WOLF_COINS = 99999;
+  private readonly WOLF_HAMMERS = 99;
+
+  // Konami code bonuses
+  private readonly KONAMI_COINS = 500;
+  private readonly KONAMI_HAMMERS = 10;
+
+  // Secret click bonuses
+  private readonly SECRET_CLICK_COINS = 250;
+  private readonly SECRET_CLICK_HAMMERS = 5;
+
+  // Date-based bonuses
+  private readonly DATE_BONUS_COINS = 100;
+  private readonly DATE_BONUS_HAMMERS = 3;
+
+  // Konami code sequence: ↑ ↑ ↓ ↓ ← → ← → B A
+  private readonly KONAMI_CODE = [
+    'ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown',
+    'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight',
+    'KeyB', 'KeyA'
+  ];
+  private konamiIndex = 0;
+  private konamiTimeout: number | null = null;
+
+  // Secret click sequence: click corner cells in order (TL, TR, BR, BL, TL)
+  private readonly SECRET_CLICK_SEQUENCE = ['TL', 'TR', 'BR', 'BL', 'TL'];
+  private clickSequenceIndex = 0;
+  private clickTimeout: number | null = null;
+
+  // Board layout for corner cell detection
+  private boardLayout: BoardLayout | null = null;
+
+  // Track which easter eggs are active
+  private wolfMode = false;
+  private konamiMode = false;
+  private secretClickMode = false;
+  private dateBonus: string | null = null;
+  private activatedEggs: string[] = [];
+
+  // Callback for visual effects
+  private onEasterEggActivated: ((eggName: string, message: string) => void) | null = null;
+
+  private constructor() {
+    // Private constructor for singleton
+  }
+
+  public static getInstance(): EasterEggManager {
+    if (!EasterEggManager.instance) {
+      EasterEggManager.instance = new EasterEggManager();
+    }
+    return EasterEggManager.instance;
+  }
+
+  /**
+   * Reset the singleton instance (useful for testing)
+   */
+  public static resetInstance(): void {
+    if (EasterEggManager.instance) {
+      EasterEggManager.instance.cleanup();
+    }
+    EasterEggManager.instance = null as any;
+  }
+
+  /**
+   * Set callback for when easter eggs are activated (for visual feedback)
+   */
+  public setActivationCallback(callback: (eggName: string, message: string) => void): void {
+    this.onEasterEggActivated = callback;
+  }
+
+  /**
+   * Initialize all easter egg listeners
+   * Should be called during game initialization
+   * @param boardLayout - Optional board layout for corner cell detection
+   */
+  public initialize(boardLayout?: BoardLayout): void {
+    if (boardLayout) {
+      this.boardLayout = boardLayout;
+    }
+    this.checkURLParams();
+    this.checkDateBonuses();
+    this.setupKonamiCodeListener();
+    this.setupSecretClickListener();
+    console.log('[EasterEgg] Easter egg system initialized');
+  }
+
+  /**
+   * Set board layout for corner cell detection
+   * Can be called after initialization if board dimensions change
+   */
+  public setBoardLayout(layout: BoardLayout): void {
+    this.boardLayout = layout;
+    console.log(`[EasterEgg] Board layout set: ${layout.cols}x${layout.rows} at (${layout.offsetX}, ${layout.offsetY})`);
+  }
+
+  /**
+   * Cleanup event listeners
+   */
+  public cleanup(): void {
+    document.removeEventListener('keydown', this.handleKeyDown);
+    document.removeEventListener('click', this.handleClick);
+    if (this.konamiTimeout) {
+      window.clearTimeout(this.konamiTimeout);
+    }
+    if (this.clickTimeout) {
+      window.clearTimeout(this.clickTimeout);
+    }
+  }
+
+  // === URL Parameter Easter Eggs ===
+
+  /**
+   * Check URL parameters and activate any easter eggs
+   */
+  public checkURLParams(): void {
+    const urlParams = new URLSearchParams(window.location.search);
+
+    // Check for wolf=true parameter
+    if (urlParams.get('wolf') === 'true') {
+      this.activateWolfMode();
+    }
+  }
+
+  /**
+   * Activate wolf mode - grants max resources for testing/fun
+   */
+  public activateWolfMode(): void {
+    if (this.wolfMode) {
+      console.log('[EasterEgg] Wolf mode already active!');
+      return;
+    }
+
+    console.log('[EasterEgg] 🐺 WOLF MODE ACTIVATED! 🐺');
+
+    const metaManager = MetaProgressionManager.getInstance();
+    const powerUpManager = PowerUpManager.getInstance();
+
+    // Grant massive coins
+    metaManager.addCoins(this.WOLF_COINS);
+    console.log(`[EasterEgg] Granted ${this.WOLF_COINS} coins`);
+
+    // Max out lives
+    const currentLives = metaManager.getLives();
+    const maxLives = metaManager.getMaxLives();
+    const livesToAdd = maxLives - currentLives;
+    for (let i = 0; i < livesToAdd; i++) {
+      metaManager.addLife();
+    }
+    console.log(`[EasterEgg] Lives set to maximum (${maxLives})`);
+
+    // Grant hammers
+    powerUpManager.add(PowerUpType.HAMMER, this.WOLF_HAMMERS);
+    console.log(`[EasterEgg] Granted ${this.WOLF_HAMMERS} hammers`);
+
+    this.wolfMode = true;
+    this.activatedEggs.push('wolf');
+
+    console.log('[EasterEgg] 🐺 You are now in god mode! Have fun! 🐺');
+    this.notifyActivation('wolf', '🐺 WOLF MODE! God mode activated!');
+  }
+
+  // === Konami Code Easter Egg ===
+
+  /**
+   * Setup keyboard listener for Konami code
+   */
+  private setupKonamiCodeListener(): void {
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+    document.addEventListener('keydown', this.handleKeyDown);
+  }
+
+  private handleKeyDown = (event: KeyboardEvent): void => {
+    // Reset timeout on any key press
+    if (this.konamiTimeout) {
+      window.clearTimeout(this.konamiTimeout);
+    }
+
+    // Check if the key matches the expected key in sequence
+    if (event.code === this.KONAMI_CODE[this.konamiIndex]) {
+      this.konamiIndex++;
+
+      // Check if sequence complete
+      if (this.konamiIndex === this.KONAMI_CODE.length) {
+        this.activateKonamiCode();
+        this.konamiIndex = 0;
+      } else {
+        // Set timeout to reset sequence after 2 seconds of inactivity
+        this.konamiTimeout = window.setTimeout(() => {
+          this.konamiIndex = 0;
+        }, 2000);
+      }
+    } else {
+      // Wrong key, reset sequence
+      this.konamiIndex = 0;
+    }
+  };
+
+  /**
+   * Activate Konami code bonus
+   */
+  private activateKonamiCode(): void {
+    if (this.konamiMode) {
+      console.log('[EasterEgg] Konami code already activated this session!');
+      return;
+    }
+
+    console.log('[EasterEgg] 🎮 KONAMI CODE ACTIVATED! 🎮');
+    console.log('[EasterEgg] ↑ ↑ ↓ ↓ ← → ← → B A');
+
+    const metaManager = MetaProgressionManager.getInstance();
+    const powerUpManager = PowerUpManager.getInstance();
+
+    // Grant bonus coins
+    metaManager.addCoins(this.KONAMI_COINS);
+    console.log(`[EasterEgg] Granted ${this.KONAMI_COINS} coins`);
+
+    // Grant bonus hammers
+    powerUpManager.add(PowerUpType.HAMMER, this.KONAMI_HAMMERS);
+    console.log(`[EasterEgg] Granted ${this.KONAMI_HAMMERS} hammers`);
+
+    this.konamiMode = true;
+    this.activatedEggs.push('konami');
+
+    console.log('[EasterEgg] 🎮 Classic cheat code nostalgia! 🎮');
+    this.notifyActivation('konami', '🎮 KONAMI CODE! +500 coins, +10 hammers!');
+  }
+
+  // === Secret Click Sequence Easter Egg ===
+
+  /**
+   * Setup click listener for secret corner sequence
+   */
+  private setupSecretClickListener(): void {
+    this.handleClick = this.handleClick.bind(this);
+    document.addEventListener('click', this.handleClick);
+  }
+
+  private handleClick = (event: MouseEvent): void => {
+    // Reset timeout on any click
+    if (this.clickTimeout) {
+      window.clearTimeout(this.clickTimeout);
+    }
+
+    const corner = this.getCorner(event.clientX, event.clientY);
+    if (!corner) {
+      // Click not in a corner, reset sequence
+      this.clickSequenceIndex = 0;
+      return;
+    }
+
+    // Check if the corner matches the expected corner in sequence
+    if (corner === this.SECRET_CLICK_SEQUENCE[this.clickSequenceIndex]) {
+      this.clickSequenceIndex++;
+
+      // Check if sequence complete
+      if (this.clickSequenceIndex === this.SECRET_CLICK_SEQUENCE.length) {
+        this.activateSecretClick();
+        this.clickSequenceIndex = 0;
+      } else {
+        // Set timeout to reset sequence after 3 seconds of inactivity
+        this.clickTimeout = window.setTimeout(() => {
+          this.clickSequenceIndex = 0;
+        }, 3000);
+      }
+    } else {
+      // Wrong corner, reset sequence
+      this.clickSequenceIndex = 0;
+    }
+  };
+
+  /**
+   * Determine which corner cell of the board was clicked
+   * Returns null if board layout not set or click is not on a corner cell
+   */
+  private getCorner(x: number, y: number): string | null {
+    if (!this.boardLayout) {
+      return null;
+    }
+
+    const { offsetX, offsetY, cellSize, rows, cols } = this.boardLayout;
+
+    // Get the canvas element to calculate offset from page
+    const canvas = document.querySelector('canvas');
+    if (!canvas) {
+      return null;
+    }
+
+    const canvasRect = canvas.getBoundingClientRect();
+    const canvasX = x - canvasRect.left;
+    const canvasY = y - canvasRect.top;
+
+    // Calculate which cell was clicked (if any)
+    const col = Math.floor((canvasX - offsetX) / cellSize);
+    const row = Math.floor((canvasY - offsetY) / cellSize);
+
+    // Check if click is within the board bounds
+    if (col < 0 || col >= cols || row < 0 || row >= rows) {
+      return null;
+    }
+
+    // Check if click is on a corner cell
+    const isTopRow = row === 0;
+    const isBottomRow = row === rows - 1;
+    const isLeftCol = col === 0;
+    const isRightCol = col === cols - 1;
+
+    if (isTopRow && isLeftCol) return 'TL';
+    if (isTopRow && isRightCol) return 'TR';
+    if (isBottomRow && isRightCol) return 'BR';
+    if (isBottomRow && isLeftCol) return 'BL';
+
+    return null;
+  }
+
+  /**
+   * Activate secret click sequence bonus
+   */
+  private activateSecretClick(): void {
+    if (this.secretClickMode) {
+      console.log('[EasterEgg] Secret click already activated this session!');
+      return;
+    }
+
+    console.log('[EasterEgg] 🔮 SECRET CLICK SEQUENCE ACTIVATED! 🔮');
+    console.log('[EasterEgg] You found the hidden corner pattern!');
+
+    const metaManager = MetaProgressionManager.getInstance();
+    const powerUpManager = PowerUpManager.getInstance();
+
+    // Grant bonus coins
+    metaManager.addCoins(this.SECRET_CLICK_COINS);
+    console.log(`[EasterEgg] Granted ${this.SECRET_CLICK_COINS} coins`);
+
+    // Grant bonus hammers
+    powerUpManager.add(PowerUpType.HAMMER, this.SECRET_CLICK_HAMMERS);
+    console.log(`[EasterEgg] Granted ${this.SECRET_CLICK_HAMMERS} hammers`);
+
+    this.secretClickMode = true;
+    this.activatedEggs.push('secretClick');
+
+    console.log('[EasterEgg] 🔮 You have keen eyes! 🔮');
+    this.notifyActivation('secretClick', '🔮 SECRET FOUND! +250 coins, +5 hammers!');
+  }
+
+  // === Date-Based Easter Eggs ===
+
+  /**
+   * Check for special date bonuses
+   */
+  public checkDateBonuses(): void {
+    const today = new Date();
+    const month = today.getMonth() + 1; // 0-indexed
+    const day = today.getDate();
+
+    let bonusName: string | null = null;
+    let emoji = '';
+    let message = '';
+
+    // Check for special dates
+    if (month === 1 && day === 1) {
+      bonusName = 'newYear';
+      emoji = '🎆';
+      message = 'Happy New Year!';
+    } else if (month === 2 && day === 14) {
+      bonusName = 'valentine';
+      emoji = '💝';
+      message = "Happy Valentine's Day!";
+    } else if (month === 3 && day === 17) {
+      bonusName = 'stPatrick';
+      emoji = '☘️';
+      message = "Happy St. Patrick's Day!";
+    } else if (month === 4 && day === 1) {
+      bonusName = 'aprilFools';
+      emoji = '🃏';
+      message = "April Fools' Day!";
+    } else if (month === 7 && day === 4) {
+      bonusName = 'independence';
+      emoji = '🎆';
+      message = 'Happy 4th of July!';
+    } else if (month === 10 && day === 31) {
+      bonusName = 'halloween';
+      emoji = '🎃';
+      message = 'Happy Halloween!';
+    } else if (month === 12 && day === 25) {
+      bonusName = 'christmas';
+      emoji = '🎄';
+      message = 'Merry Christmas!';
+    } else if (month === 12 && day === 31) {
+      bonusName = 'newYearsEve';
+      emoji = '🥳';
+      message = "Happy New Year's Eve!";
+    }
+
+    if (bonusName) {
+      this.activateDateBonus(bonusName, emoji, message);
+    }
+  }
+
+  /**
+   * Activate date-based bonus
+   */
+  private activateDateBonus(bonusName: string, emoji: string, message: string): void {
+    // Check if already activated today (using localStorage)
+    const storageKey = `easterEgg_date_${bonusName}_${new Date().toDateString()}`;
+    if (localStorage.getItem(storageKey)) {
+      console.log(`[EasterEgg] ${message} bonus already claimed today!`);
+      return;
+    }
+
+    console.log(`[EasterEgg] ${emoji} ${message} ${emoji}`);
+    console.log('[EasterEgg] Special date bonus activated!');
+
+    const metaManager = MetaProgressionManager.getInstance();
+    const powerUpManager = PowerUpManager.getInstance();
+
+    // Grant bonus coins
+    metaManager.addCoins(this.DATE_BONUS_COINS);
+    console.log(`[EasterEgg] Granted ${this.DATE_BONUS_COINS} coins`);
+
+    // Grant bonus hammers
+    powerUpManager.add(PowerUpType.HAMMER, this.DATE_BONUS_HAMMERS);
+    console.log(`[EasterEgg] Granted ${this.DATE_BONUS_HAMMERS} hammers`);
+
+    // Mark as claimed for today
+    localStorage.setItem(storageKey, 'true');
+
+    this.dateBonus = bonusName;
+    this.activatedEggs.push(`date:${bonusName}`);
+
+    console.log(`[EasterEgg] ${emoji} Enjoy your special day bonus! ${emoji}`);
+    this.notifyActivation('date', `${emoji} ${message} +100 coins, +3 hammers!`);
+  }
+
+  // === Utility Methods ===
+
+  /**
+   * Notify activation callback if set
+   */
+  private notifyActivation(eggName: string, message: string): void {
+    if (this.onEasterEggActivated) {
+      this.onEasterEggActivated(eggName, message);
+    }
+  }
+
+  /**
+   * Check if wolf mode is active
+   */
+  public isWolfModeActive(): boolean {
+    return this.wolfMode;
+  }
+
+  /**
+   * Check if Konami code is active
+   */
+  public isKonamiModeActive(): boolean {
+    return this.konamiMode;
+  }
+
+  /**
+   * Check if secret click is active
+   */
+  public isSecretClickModeActive(): boolean {
+    return this.secretClickMode;
+  }
+
+  /**
+   * Get current date bonus name (if any)
+   */
+  public getDateBonus(): string | null {
+    return this.dateBonus;
+  }
+
+  /**
+   * Get status of all easter eggs
+   */
+  public getStatus(): EasterEggStatus {
+    return {
+      wolfMode: this.wolfMode,
+      konamiMode: this.konamiMode,
+      secretClickMode: this.secretClickMode,
+      dateBonus: this.dateBonus,
+      activated: [...this.activatedEggs]
+    };
+  }
+
+  /**
+   * Deactivate all easter eggs (useful for testing)
+   */
+  public deactivateAll(): void {
+    this.wolfMode = false;
+    this.konamiMode = false;
+    this.secretClickMode = false;
+    this.dateBonus = null;
+    this.activatedEggs = [];
+    this.konamiIndex = 0;
+    this.clickSequenceIndex = 0;
+    console.log('[EasterEgg] All easter eggs deactivated');
+  }
+}

--- a/src/game/EasterEggManager.ts
+++ b/src/game/EasterEggManager.ts
@@ -124,11 +124,82 @@ export class EasterEggManager {
   }
 
   /**
+   * Called when a gem is clicked/selected in the game
+   * This is the preferred way to detect corner clicks - uses actual gem selection
+   */
+  public onGemClicked(row: number, col: number): void {
+    if (!this.boardLayout) {
+      return;
+    }
+
+    const { rows, cols } = this.boardLayout;
+    const corner = this.getCornerFromCell(row, col, rows, cols);
+
+    if (corner) {
+      console.log(`[EasterEgg] Gem clicked at (${row}, ${col}) -> corner: ${corner}`);
+      this.processCornerClick(corner);
+    }
+  }
+
+  /**
+   * Determine if a cell is a corner based on row/col
+   */
+  private getCornerFromCell(row: number, col: number, rows: number, cols: number): string | null {
+    const isTopRow = row === 0;
+    const isBottomRow = row === rows - 1;
+    const isLeftCol = col === 0;
+    const isRightCol = col === cols - 1;
+
+    if (isTopRow && isLeftCol) return 'TL';
+    if (isTopRow && isRightCol) return 'TR';
+    if (isBottomRow && isRightCol) return 'BR';
+    if (isBottomRow && isLeftCol) return 'BL';
+
+    return null;
+  }
+
+  /**
+   * Process a corner click for the secret sequence
+   */
+  private processCornerClick(corner: string): void {
+    // Reset timeout on any corner click
+    if (this.clickTimeout) {
+      window.clearTimeout(this.clickTimeout);
+    }
+
+    console.log(`[EasterEgg] Corner sequence: got ${corner}, index ${this.clickSequenceIndex}, expected ${this.SECRET_CLICK_SEQUENCE[this.clickSequenceIndex]}`);
+
+    // Check if the corner matches the expected corner in sequence
+    if (corner === this.SECRET_CLICK_SEQUENCE[this.clickSequenceIndex]) {
+      this.clickSequenceIndex++;
+
+      // Check if sequence complete
+      if (this.clickSequenceIndex === this.SECRET_CLICK_SEQUENCE.length) {
+        this.activateSecretClick();
+        this.clickSequenceIndex = 0;
+      } else {
+        // Set timeout to reset sequence after 3 seconds of inactivity
+        this.clickTimeout = window.setTimeout(() => {
+          console.log('[EasterEgg] Corner sequence timed out, resetting');
+          this.clickSequenceIndex = 0;
+        }, 3000);
+      }
+    } else {
+      // Wrong corner, reset sequence
+      console.log(`[EasterEgg] Wrong corner, resetting sequence`);
+      this.clickSequenceIndex = 0;
+    }
+  }
+
+  /**
    * Cleanup event listeners
    */
   public cleanup(): void {
     document.removeEventListener('keydown', this.handleKeyDown);
-    document.removeEventListener('click', this.handleClick);
+    const canvas = document.querySelector('canvas');
+    if (canvas) {
+      canvas.removeEventListener('click', this.handleCanvasClick);
+    }
     if (this.konamiTimeout) {
       window.clearTimeout(this.konamiTimeout);
     }
@@ -259,88 +330,49 @@ export class EasterEggManager {
 
   /**
    * Setup click listener for secret corner sequence
+   * Uses canvas click detection to determine which cell was clicked
    */
   private setupSecretClickListener(): void {
-    this.handleClick = this.handleClick.bind(this);
-    document.addEventListener('click', this.handleClick);
+    // Wait for canvas to be created, then attach listener
+    this.setupCanvasClickListener();
   }
 
-  private handleClick = (event: MouseEvent): void => {
-    // Reset timeout on any click
-    if (this.clickTimeout) {
-      window.clearTimeout(this.clickTimeout);
-    }
-
-    const corner = this.getCorner(event.clientX, event.clientY);
-    if (!corner) {
-      // Click not in a corner, reset sequence
-      this.clickSequenceIndex = 0;
-      return;
-    }
-
-    // Check if the corner matches the expected corner in sequence
-    if (corner === this.SECRET_CLICK_SEQUENCE[this.clickSequenceIndex]) {
-      this.clickSequenceIndex++;
-
-      // Check if sequence complete
-      if (this.clickSequenceIndex === this.SECRET_CLICK_SEQUENCE.length) {
-        this.activateSecretClick();
-        this.clickSequenceIndex = 0;
-      } else {
-        // Set timeout to reset sequence after 3 seconds of inactivity
-        this.clickTimeout = window.setTimeout(() => {
-          this.clickSequenceIndex = 0;
-        }, 3000);
-      }
-    } else {
-      // Wrong corner, reset sequence
-      this.clickSequenceIndex = 0;
-    }
-  };
-
   /**
-   * Determine which corner cell of the board was clicked
-   * Returns null if board layout not set or click is not on a corner cell
+   * Setup click listener on canvas element (may not exist immediately)
    */
-  private getCorner(x: number, y: number): string | null {
+  private setupCanvasClickListener(): void {
+    const canvas = document.querySelector('canvas');
+    if (canvas) {
+      canvas.addEventListener('click', this.handleCanvasClick);
+      console.log('[EasterEgg] Canvas click listener attached');
+    } else {
+      // Canvas doesn't exist yet, try again after a short delay
+      setTimeout(() => this.setupCanvasClickListener(), 100);
+    }
+  }
+
+  private handleCanvasClick = (event: MouseEvent): void => {
     if (!this.boardLayout) {
-      return null;
+      return;
     }
 
     const { offsetX, offsetY, cellSize, rows, cols } = this.boardLayout;
 
-    // Get the canvas element to calculate offset from page
-    const canvas = document.querySelector('canvas');
-    if (!canvas) {
-      return null;
-    }
+    const canvas = event.target as HTMLCanvasElement;
+    const rect = canvas.getBoundingClientRect();
+    const canvasX = event.clientX - rect.left;
+    const canvasY = event.clientY - rect.top;
 
-    const canvasRect = canvas.getBoundingClientRect();
-    const canvasX = x - canvasRect.left;
-    const canvasY = y - canvasRect.top;
-
-    // Calculate which cell was clicked (if any)
+    // Calculate which cell was clicked
     const col = Math.floor((canvasX - offsetX) / cellSize);
     const row = Math.floor((canvasY - offsetY) / cellSize);
 
-    // Check if click is within the board bounds
-    if (col < 0 || col >= cols || row < 0 || row >= rows) {
-      return null;
+    // Check if click is within board bounds
+    if (col >= 0 && col < cols && row >= 0 && row < rows) {
+      // Use onGemClicked to process the corner detection
+      this.onGemClicked(row, col);
     }
-
-    // Check if click is on a corner cell
-    const isTopRow = row === 0;
-    const isBottomRow = row === rows - 1;
-    const isLeftCol = col === 0;
-    const isRightCol = col === cols - 1;
-
-    if (isTopRow && isLeftCol) return 'TL';
-    if (isTopRow && isRightCol) return 'TR';
-    if (isBottomRow && isRightCol) return 'BR';
-    if (isBottomRow && isLeftCol) return 'BL';
-
-    return null;
-  }
+  };
 
   /**
    * Activate secret click sequence bonus
@@ -467,9 +499,127 @@ export class EasterEggManager {
    * Notify activation callback if set
    */
   private notifyActivation(eggName: string, message: string): void {
+    // Show visual celebration
+    this.showCelebration(eggName, message);
+
     if (this.onEasterEggActivated) {
       this.onEasterEggActivated(eggName, message);
     }
+  }
+
+  /**
+   * Show a celebratory popup when an easter egg is found
+   */
+  private showCelebration(eggName: string, message: string): void {
+    // Create overlay
+    const overlay = document.createElement('div');
+    overlay.id = 'easter-egg-celebration';
+    overlay.style.cssText = `
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.8);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      z-index: 10000;
+      animation: fadeIn 0.3s ease-out;
+    `;
+
+    // Create popup container
+    const popup = document.createElement('div');
+    popup.style.cssText = `
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      border-radius: 20px;
+      padding: 40px 60px;
+      text-align: center;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+      animation: popIn 0.4s ease-out;
+      max-width: 90%;
+    `;
+
+    // Get emoji and title based on egg type
+    let emoji = '🎉';
+    let title = 'Easter Egg Found!';
+    if (eggName === 'wolf') {
+      emoji = '🐺';
+      title = 'WOLF MODE!';
+    } else if (eggName === 'konami') {
+      emoji = '🎮';
+      title = 'KONAMI CODE!';
+    } else if (eggName === 'secretClick') {
+      emoji = '🔮';
+      title = 'SECRET DISCOVERED!';
+    } else if (eggName === 'date') {
+      emoji = message.split(' ')[0]; // Get emoji from message
+      title = 'HOLIDAY BONUS!';
+    }
+
+    popup.innerHTML = `
+      <div style="font-size: 80px; margin-bottom: 20px; animation: bounce 0.6s ease infinite;">${emoji}</div>
+      <h1 style="color: #fff; font-size: 32px; margin: 0 0 15px 0; text-shadow: 2px 2px 4px rgba(0,0,0,0.3);">${title}</h1>
+      <p style="color: #e0e0e0; font-size: 18px; margin: 0 0 25px 0;">${message}</p>
+      <button id="easter-egg-close" style="
+        background: #fff;
+        color: #764ba2;
+        border: none;
+        padding: 12px 40px;
+        font-size: 18px;
+        font-weight: bold;
+        border-radius: 25px;
+        cursor: pointer;
+        transition: transform 0.2s;
+      ">Awesome!</button>
+    `;
+
+    overlay.appendChild(popup);
+    document.body.appendChild(overlay);
+
+    // Add CSS animations
+    const style = document.createElement('style');
+    style.textContent = `
+      @keyframes fadeIn {
+        from { opacity: 0; }
+        to { opacity: 1; }
+      }
+      @keyframes popIn {
+        from { transform: scale(0.5); opacity: 0; }
+        to { transform: scale(1); opacity: 1; }
+      }
+      @keyframes bounce {
+        0%, 100% { transform: translateY(0); }
+        50% { transform: translateY(-10px); }
+      }
+      #easter-egg-close:hover {
+        transform: scale(1.05);
+      }
+    `;
+    document.head.appendChild(style);
+
+    // Close button handler
+    const closeBtn = document.getElementById('easter-egg-close');
+    if (closeBtn) {
+      closeBtn.addEventListener('click', () => {
+        overlay.style.animation = 'fadeIn 0.2s ease-out reverse';
+        setTimeout(() => {
+          overlay.remove();
+          style.remove();
+        }, 200);
+      });
+    }
+
+    // Also close on overlay click (outside popup)
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) {
+        overlay.style.animation = 'fadeIn 0.2s ease-out reverse';
+        setTimeout(() => {
+          overlay.remove();
+          style.remove();
+        }, 200);
+      }
+    });
   }
 
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { LevelScene } from './scenes/LevelScene';
 import { EndLevelScene } from './scenes/EndLevelScene';
 import { ShopScene } from './scenes/ShopScene';
 import { BoardConfig } from './game/BoardConfig';
+import { EasterEggManager } from './game/EasterEggManager';
 
 // Calculate required canvas size based on board dimensions
 const boardConfig = BoardConfig.fromURL();
@@ -34,5 +35,15 @@ const config: Phaser.Types.Core.GameConfig = {
 };
 
 console.log(`[Game] Canvas size: ${canvasWidth}×${canvasHeight} for ${boardConfig.rows}×${boardConfig.cols} board`);
+
+// Initialize easter egg system (URL params, Konami code, click sequences, date bonuses)
+const easterEggManager = EasterEggManager.getInstance();
+easterEggManager.initialize({
+  offsetX: BOARD_OFFSET_X,
+  offsetY: BOARD_OFFSET_Y,
+  cellSize: CELL_SIZE,
+  rows: boardConfig.rows,
+  cols: boardConfig.cols
+});
 
 new Phaser.Game(config);

--- a/src/scenes/LevelScene.ts
+++ b/src/scenes/LevelScene.ts
@@ -4,6 +4,7 @@ import { BoardConfig } from '../game/BoardConfig';
 import { LevelObjectives, LevelStatus } from '../game/LevelObjectives';
 import { LevelSettings } from '../game/LevelConfig';
 import { MetaProgressionManager } from '../game/MetaProgressionManager';
+import { EasterEggManager } from '../game/EasterEggManager';
 
 interface GemSprite {
   circle: any; // Phaser.GameObjects.Circle type not exported correctly
@@ -178,6 +179,15 @@ export class LevelScene extends Phaser.Scene {
     // Log helpful info
     console.log(`[Game] Board initialized: ${config.rows}x${config.cols}`);
     console.log('[Game] Try: gameConfig.listPresets() to see available boards');
+
+    // Update easter egg manager with current board layout for corner click detection
+    EasterEggManager.getInstance().setBoardLayout({
+      offsetX: this.BOARD_OFFSET_X,
+      offsetY: this.BOARD_OFFSET_Y,
+      cellSize: this.CELL_SIZE,
+      rows: config.rows,
+      cols: config.cols
+    });
 
     // Signal that scene is ready for E2E tests
     const domStatus = document.getElementById('game-status');
@@ -654,6 +664,9 @@ export class LevelScene extends Phaser.Scene {
 
   private onGemClick(row: number, col: number): void {
     const clickedPos = { row, col };
+
+    // Notify easter egg manager of gem click (for corner sequence detection)
+    EasterEggManager.getInstance().onGemClicked(row, col);
 
     // If in hammer mode, use hammer on this gem
     if (this.hammerMode) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,6 @@ export default defineConfig({
     }
   },
   server: {
-    port: 3000
+    port: 3035  // Unique port for easter-eggs feature branch (issue #35)
   }
 })


### PR DESCRIPTION
## Summary
- Add `wolf=true` URL parameter for god mode (99,999 coins, max lives, 99 hammers)
- Add Konami code easter egg (↑↑↓↓←→←→BA) for 500 coins and 10 hammers
- Add secret corner click sequence (click board corner cells) for 250 coins and 5 hammers
- Add date-based bonuses for 8 special holidays (New Year, Valentine's, St. Patrick's, April Fools, July 4th, Halloween, Christmas, New Year's Eve)
- Create `EASTER_EGGS.md` documentation with instructions for finding all easter eggs

Closes #35

## Test plan
- [ ] Test `?wolf=true` URL parameter grants resources
- [ ] Test Konami code sequence (↑↑↓↓←→←→BA) activates bonus
- [ ] Test corner cell click sequence (TL→TR→BR→BL→TL on board) activates bonus
- [ ] Verify each easter egg can only be activated once per session
- [ ] Check console logs show activation messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)